### PR TITLE
commandline: Do not crash on device open error.

### DIFF
--- a/commandline/library/micronucleus_lib.c
+++ b/commandline/library/micronucleus_lib.c
@@ -30,6 +30,9 @@
 #include "micronucleus_lib.h"
 #include "littleWire_util.h"
 
+#include <string.h>
+#include <errno.h>
+
 micronucleus* micronucleus_connect(int fast_mode) {
   micronucleus *nucleus = NULL;
   struct usb_bus *busses;
@@ -61,6 +64,10 @@ micronucleus* micronucleus_connect(int fast_mode) {
         }
 
         nucleus->device = usb_open(dev);
+        if (!nucleus->device) {
+                fprintf(stderr, "Error opening bus %s device %s: %s\n", bus->dirname, dev->filename, strerror(errno));
+                return NULL;
+        }
 
         if (nucleus->version.major>=2) {  // Version 2.x
           // get nucleus info


### PR DESCRIPTION
When using with older micronucleus that does not drop the USB data lines
the Digispark appears connected but uncommunicative while user program
is running. Trying to open such device fails giving a NULL pointer. Do
not dereference it.